### PR TITLE
Make "More..." a text link, add host to "Back"

### DIFF
--- a/gopherpedia.rb
+++ b/gopherpedia.rb
@@ -83,13 +83,13 @@ menu :about do
   block "So, I built Gopherpedia. It runs on Gopher2000 (https://github.com/muffinista/gopher2000), a Ruby library I wrote for developing Gopher services. The web proxy to Gopherpedia is GoPHPer (https://github.com/muffinista/gophper-proxy), which I also wrote."
   br
 
-  link "more about the Gopher protocol", "Gopher (protocol)", 'gopherpedia.com'
+  text_link "more about the Gopher protocol", "Gopher (protocol)", 'gopherpedia.com'
 
   http "gopher2000 - a ruby gopher server", "http://github.com/muffinista/gopher2000"
   http "gophper-proxy - a modern PHP gopher proxy", "http://github.com/muffinista/gophper-proxy"
 
   br
-  menu "back to gopherpedia", "/"
+  menu "back to gopherpedia", "/", 'gopherpedia.com'
 end
 
 


### PR DESCRIPTION
Follow up to https://github.com/muffinista/gopher2000/issues/4. The "More..." link is showing up as Gopher item type `9` which makes some clients (like [Gopher Commons](https://gopher.commons.host/gopher://gopherpedia.com/1/about)) download the content rather than browse to it. Also added the hostname to the "Back" link, which was assuming `0.0.0.0`. 