### PR TITLE
Use error type in "oops" page

### DIFF
--- a/gopherpedia.rb
+++ b/gopherpedia.rb
@@ -132,7 +132,7 @@ route '/:title?' do
     
       render :article, params[:title], a
     rescue StandardError => ex
-      render :error, "Error", ex.message
+      render :error, ex.message
     end
 
   else
@@ -179,7 +179,7 @@ menu :error do |code|
   text "Looks like something went wrong with that request"
   br
   br
-  text "Error #{code.to_s}"
+  error "Error #{code.to_s}"
   br
   br
   menu "back to gopherpedia", "/", 'gopherpedia.com'


### PR DESCRIPTION
I noticed that all the directory entries on the "oops" page were all `i` types; this PR modifies the one with the error details to contain a `3` (error) type instead.

I also noticed that the way the block was being called, it was rendering the display string "Error Error" instead of "Error 404" in the case of a missing page, so I tweaked that too.

The default error templates in `gopher2000` also use `text` instead of `error`; I haven't prepared a PR for that yet as I thought I'd wait to see if this change was agreeable here first before trying to get all the tests for `gopher2000` running on my machine. Cool library though, I like the DSL for the item types; makes the page templates super readable.